### PR TITLE
Add read & write TAL conditions on PST fields settings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 1.4 (unreleased)
 ----------------
 
+- Added read & write TAL conditions on PST fields settings
+  [daggelpop,fngaha]
 - Fix ecompte export issue (export now also contains subactions as actions)
   [fngaha]
 - Added fields to configure dashboards columns in pstprojectspace

--- a/src/imio/project/pst/browser/documentgenerator.py
+++ b/src/imio/project/pst/browser/documentgenerator.py
@@ -75,9 +75,9 @@ class DocumentGenerationBaseHelper():
     def init_hv(self):
         """ init method to be called in document """
 
-        def _cleanup_fields(fields):
+        def _cleanup_fields(field_schemas):
             """Handle some cases like IDublinCore.title to just keep title"""
-            return [fld.split('.')[-1] for fld in fields]
+            return [field_schema['field_name'].split('.')[-1] for field_schema in field_schemas]
 
         projectspace = getProjectSpace(self.real_context)
         self.activated_fields = {

--- a/src/imio/project/pst/content/pstprojectspace.py
+++ b/src/imio/project/pst/content/pstprojectspace.py
@@ -1,5 +1,7 @@
 from plone.autoform import directives
 from collective.eeafaceted.z3ctable import _ as _z
+from collective.z3cform.datagridfield import DataGridFieldFactory
+from collective.z3cform.datagridfield import DictRow
 from imio.project.core.content.projectspace import get_pt_fields_voc
 from imio.project.core.content.projectspace import mandatory_check
 from imio.project.core.content.projectspace import position_check
@@ -9,6 +11,7 @@ from imio.project.core.content.projectspace import ProjectSpaceSchemaPolicy
 from imio.project.core import _ as _c
 from imio.project.pst import _
 from zope import schema
+from zope.interface import Interface
 from zope.interface import implements
 from zope.interface import invariant
 from zope.schema.interfaces import IVocabularyFactory
@@ -89,35 +92,104 @@ TasksColumnsVocabulary = SimpleVocabulary(
 )
 
 
+class IStrategicObjectiveFieldsSchema(Interface):
+    field_name = schema.Choice(
+        title=_(u'Field name'),
+        vocabulary=u'imio.project.pst.SOFieldsVocabulary',
+    )
+
+    read_tal_condition = schema.TextLine(
+        title=_("Read TAL condition"),
+        required=False,
+    )
+
+    write_tal_condition = schema.TextLine(
+        title=_("Write TAL condition"),
+        required=False,
+    )
+
+
+class IOperationalObjectiveFieldsSchema(Interface):
+    field_name = schema.Choice(
+        title=_(u'Field name'),
+        vocabulary=u'imio.project.pst.OOFieldsVocabulary',
+    )
+
+    read_tal_condition = schema.TextLine(
+        title=_("Read TAL condition"),
+        required=False,
+    )
+
+    write_tal_condition = schema.TextLine(
+        title=_("Write TAL condition"),
+        required=False,
+    )
+
+
+class IPSTActionFieldsSchema(Interface):
+    field_name = schema.Choice(
+        title=_(u'Field name'),
+        vocabulary=u'imio.project.pst.ActionFieldsVocabulary',
+    )
+
+    read_tal_condition = schema.TextLine(
+        title=_("Read TAL condition"),
+        required=False,
+    )
+
+    write_tal_condition = schema.TextLine(
+        title=_("Write TAL condition"),
+        required=False,
+    )
+
+
 class IPSTProjectSpace(IProjectSpace):
     """
         PST Project schema
     """
     strategicobjective_fields = schema.List(
         title=_c(u"${type} fields display", mapping={'type': _('StrategicObjective')}),
-        description=_c(u"Put fields on the right to display it. Flags are : ..."),
-        value_type=schema.Choice(vocabulary=u'imio.project.pst.SOFieldsVocabulary'),
-        # value_type=schema.Choice(source=IMFields),  # a source is not managed by registry !!
+        required=False,
+        value_type=DictRow(title=_(u'Field'),
+                           schema=IStrategicObjectiveFieldsSchema,
+                           required=False),
     )
+    directives.widget('strategicobjective_fields', DataGridFieldFactory, display_table_css_class='listing',
+                      allow_reorder=True, auto_append=False)
+
 
     operationalobjective_fields = schema.List(
         title=_c(u"${type} fields display", mapping={'type': _('OperationalObjective')}),
-        # description=_c(u'Put fields on the right to display it. Flags are : ...'),
-        value_type=schema.Choice(vocabulary=u'imio.project.pst.OOFieldsVocabulary'),
+        required=False,
+        value_type=DictRow(title=_(u'Field'),
+                           schema=IOperationalObjectiveFieldsSchema,
+                           required=False),
     )
+    directives.widget('operationalobjective_fields', DataGridFieldFactory, display_table_css_class='listing',
+                      allow_reorder=True, auto_append=False)
+
 
     pstaction_fields = schema.List(
         title=_c(u"${type} fields display", mapping={'type': _('PSTAction')}),
-        # description=_c(u'Put fields on the right to display it. Flags are : ...'),
-        value_type=schema.Choice(vocabulary=u'imio.project.pst.ActionFieldsVocabulary'),
+        required=False,
+        value_type=DictRow(title=_(u'Field'),
+                           schema=IPSTActionFieldsSchema,
+                           required=False),
     )
+    directives.widget('pstaction_fields', DataGridFieldFactory, display_table_css_class='listing',
+                      allow_reorder=True, auto_append=False)
+
 
     # this field will be hidden
     pstsubaction_fields = schema.List(
         title=_c(u"${type} fields display", mapping={'type': _('PSTSubAction')}),
-        # description=_c(u'Put fields on the right to display it. Flags are : ...'),
-        value_type=schema.Choice(vocabulary=u'imio.project.pst.ActionFieldsVocabulary'),
+        required=False,
+        value_type=DictRow(title=_(u'Field'),
+                           schema=IPSTActionFieldsSchema,
+                           required=False),
     )
+    directives.widget('pstsubaction_fields', DataGridFieldFactory, display_table_css_class='listing',
+                      allow_reorder=True, auto_append=False)
 
     strategicobjectives_columns = schema.List(
         title=_(u"StrategicObjective columns"),

--- a/src/imio/project/pst/migrations/migrate_to_1_3_1.py
+++ b/src/imio/project/pst/migrations/migrate_to_1_3_1.py
@@ -32,28 +32,15 @@ class Migrate_To_1_3_1(Migrator):
                 else:
                     list_fields.append('plan')
 
-    def migrate_pst_fields(self):
-        projectspace_brains = self.catalog(portal_type='pstprojectspace')
-        for projectspace_brain in projectspace_brains:
-            projectspace_obj = projectspace_brain.getObject()
-
-            for pst_field_name in (
-                'strategicobjective_fields',
-                'operationalobjective_fields',
-                'pstaction_fields',
-                'pstsubaction_fields',
-            ):
-                updated_list = []
-                for field_name in getattr(projectspace_obj, pst_field_name):
-                    if isinstance(field_name, dict):  # field migration already effective
-                        continue
-                    updated_list.append({
-                        'field_name': field_name,
-                        'read_tal_condition': '',
-                        'write_tal_condition': '',
-                    })
-                if updated_list:
-                    setattr(projectspace_obj, pst_field_name, updated_list)
+    def migrate_pst_fields(self, field_list):
+        updated_list = []
+        for field_name in field_list:
+            updated_list.append({
+                'field_name': field_name,
+                'read_tal_condition': '',
+                'write_tal_condition': '',
+            })
+        return updated_list
 
     def update_dashboards(self):
         # update daterange criteria
@@ -134,10 +121,10 @@ class Migrate_To_1_3_1(Migrator):
                     # projectspace is now pstprojectspace
                     projectspace_obj.portal_type = 'pstprojectspace'
                     projectspace_obj.project_fields = prj_fld_record
-                    projectspace_obj.strategicobjective_fields = so_record
-                    projectspace_obj.operationalobjective_fields = oo_record
-                    projectspace_obj.pstaction_fields = a_record
-                    projectspace_obj.pstsubaction_fields = sa_record
+                    projectspace_obj.strategicobjective_fields = self.migrate_pst_fields(so_record)
+                    projectspace_obj.operationalobjective_fields = self.migrate_pst_fields(oo_record)
+                    projectspace_obj.pstaction_fields = self.migrate_pst_fields(a_record)
+                    projectspace_obj.pstsubaction_fields = self.migrate_pst_fields(sa_record)
                     if not getattr(projectspace_obj, 'plan_values'):
                         setattr(projectspace_obj, 'plan_values', plan_values)
                     if not getattr(projectspace_obj, 'strategicobjective_budget_states'):

--- a/src/imio/project/pst/migrations/migrate_to_1_3_1.py
+++ b/src/imio/project/pst/migrations/migrate_to_1_3_1.py
@@ -120,7 +120,7 @@ class Migrate_To_1_3_1(Migrator):
                             new_class_name='imio.project.pst.content.pstprojectspace.PSTProjectSpace')
                     # projectspace is now pstprojectspace
                     projectspace_obj.portal_type = 'pstprojectspace'
-                    projectspace_obj.project_fields = prj_fld_record
+                    projectspace_obj.project_fields = self.migrate_pst_fields(prj_fld_record)
                     projectspace_obj.strategicobjective_fields = self.migrate_pst_fields(so_record)
                     projectspace_obj.operationalobjective_fields = self.migrate_pst_fields(oo_record)
                     projectspace_obj.pstaction_fields = self.migrate_pst_fields(a_record)
@@ -150,8 +150,6 @@ class Migrate_To_1_3_1(Migrator):
 
         # update daterange criteria
         self.update_dashboards()
-
-        self.migrate_pst_fields()
 
         # remove configlets
         config_tool = api.portal.get_tool('portal_controlpanel')

--- a/src/imio/project/pst/setuphandlers.py
+++ b/src/imio/project/pst/setuphandlers.py
@@ -354,10 +354,15 @@ def _addPSTprojectspace(context):
             'extra_concerned_people', 'IAnalyticBudget.projection',
             'IAnalyticBudget.analytic_budget', 'budget', 'budget_comments',
             'ISustainableDevelopmentGoals.sdgs', 'observation', 'comments']
-    params['strategicobjective_fields'] = strategicobjective_fields
-    params['operationalobjective_fields'] = operationalobjective_fields
-    params['pstaction_fields'] = pstaction_fields
-    params['pstsubaction_fields'] = pstaction_fields
+
+    def with_tal_permissions(fields):
+        return [{'field_name': field_name, 'read_tal_condition': '', 'write_tal_condition': ''}
+                for field_name in fields]
+
+    params['strategicobjective_fields'] = with_tal_permissions(strategicobjective_fields)
+    params['operationalobjective_fields'] = with_tal_permissions(operationalobjective_fields)
+    params['pstaction_fields'] = with_tal_permissions(pstaction_fields)
+    params['pstsubaction_fields'] = with_tal_permissions(pstaction_fields)
 
     strategicobjective_columns = [
             u'select_row', u'pretty_link', u'review_state',

--- a/src/imio/project/pst/testing.py
+++ b/src/imio/project/pst/testing.py
@@ -75,25 +75,67 @@ class IntegrationTestCase(unittest.TestCase):
         super(IntegrationTestCase, self).setUp()
         #default setup
         self.os_fields = [
-            'IDublinCore.title', 'description_rich', 'reference_number', 'categories', 'plan',
-            'IAnalyticBudget.projection', 'IAnalyticBudget.analytic_budget', 'budget', 'budget_comments',
-            'observation', 'comments'
+            {'read_tal_condition': '', 'field_name': 'IDublinCore.title', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'description_rich', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'reference_number', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'categories', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'plan', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'IAnalyticBudget.projection', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'IAnalyticBudget.analytic_budget', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'budget', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'budget_comments', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'observation', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'comments', 'write_tal_condition': ''}
         ]
         self.oo_fields = [
-            'IDublinCore.title', 'description_rich', 'reference_number', 'categories', 'plan',
-            'result_indicator', 'priority', 'planned_end_date', 'representative_responsible',
-            'administrative_responsible', 'manager', 'extra_concerned_people',
-            'IAnalyticBudget.projection', 'IAnalyticBudget.analytic_budget', 'budget', 'budget_comments',
-            'ISustainableDevelopmentGoals.sdgs', 'observation', 'comments'
+            {'read_tal_condition': '', 'field_name': 'IDublinCore.title', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'description_rich', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'reference_number', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'categories', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'plan', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'result_indicator', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'priority', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'planned_end_date', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'representative_responsible', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'administrative_responsible', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'manager', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'extra_concerned_people', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'IAnalyticBudget.projection', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'IAnalyticBudget.analytic_budget', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'budget', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'budget_comments', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'ISustainableDevelopmentGoals.sdgs', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'observation', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'comments', 'write_tal_condition': ''}
         ]
+
         self.a_fields = [
-            'IDublinCore.title', 'description_rich', 'reference_number', 'categories', 'plan',
-            'result_indicator', 'planned_end_date', 'planned_begin_date', 'effective_begin_date',
-            'effective_end_date', 'progress', 'health_indicator', 'health_indicator_details',
-            'representative_responsible', 'manager', 'responsible', 'extra_concerned_people',
-            'IAnalyticBudget.projection', 'IAnalyticBudget.analytic_budget', 'budget', 'budget_comments',
-            'ISustainableDevelopmentGoals.sdgs', 'observation', 'comments'
+            {'read_tal_condition': '', 'field_name': 'IDublinCore.title', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'description_rich', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'reference_number', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'categories', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'plan', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'result_indicator', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'planned_end_date', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'planned_begin_date', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'effective_begin_date', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'effective_end_date', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'progress', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'health_indicator', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'health_indicator_details', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'representative_responsible', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'manager', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'responsible', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'extra_concerned_people', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'IAnalyticBudget.projection', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'IAnalyticBudget.analytic_budget', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'budget', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'budget_comments', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'ISustainableDevelopmentGoals.sdgs', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'observation', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'comments', 'write_tal_condition': ''}
         ]
+
         self.os_columns = [
             u'select_row', u'pretty_link', u'review_state', u'categories', u'ModificationDate', u'history_actions'
         ]

--- a/src/imio/project/pst/tests/test_pstprojectspace.py
+++ b/src/imio/project/pst/tests/test_pstprojectspace.py
@@ -36,17 +36,35 @@ class TestPSTProjectSpace(IntegrationTestCase):
          Test hide field :
          remove categories in strategicobjectives_fields and assert that schemata fields has been updated
         """
+        import ipdb; ipdb.set_trace()
         self.assertEquals(
             self.pst.strategicobjective_fields,
-            ['IDublinCore.title', 'description_rich', 'reference_number', 'categories', 'plan',
-             'IAnalyticBudget.projection', 'IAnalyticBudget.analytic_budget', 'budget', 'budget_comments',
-             'observation', 'comments']
+            [{'read_tal_condition': '', 'field_name': 'IDublinCore.title', 'write_tal_condition': ''},
+             {'read_tal_condition': '', 'field_name': 'description_rich', 'write_tal_condition': ''},
+             {'read_tal_condition': '', 'field_name': 'reference_number', 'write_tal_condition': ''},
+             {'read_tal_condition': '', 'field_name': 'categories', 'write_tal_condition': ''},
+             {'read_tal_condition': '', 'field_name': 'plan', 'write_tal_condition': ''},
+             {'read_tal_condition': '', 'field_name': 'IAnalyticBudget.projection', 'write_tal_condition': ''},
+             {'read_tal_condition': '', 'field_name': 'IAnalyticBudget.analytic_budget', 'write_tal_condition': ''},
+             {'read_tal_condition': '', 'field_name': 'budget', 'write_tal_condition': ''},
+             {'read_tal_condition': '', 'field_name': 'budget_comments', 'write_tal_condition': ''},
+             {'read_tal_condition': '', 'field_name': 'observation', 'write_tal_condition': ''},
+             {'read_tal_condition': '', 'field_name': 'comments', 'write_tal_condition': ''}]
         )
-        self.pst.strategicobjective_fields.remove('categories')
+        self.pst.strategicobjective_fields.remove({'read_tal_condition': '', 'field_name': 'categories',
+                                                   'write_tal_condition': ''})
         self.assertEquals(
             self.pst.strategicobjective_fields,
-            ['IDublinCore.title', 'description_rich', 'reference_number', 'plan', 'IAnalyticBudget.projection',
-             'IAnalyticBudget.analytic_budget', 'budget', 'budget_comments', 'observation', 'comments']
+            [{'read_tal_condition': '', 'field_name': 'IDublinCore.title', 'write_tal_condition': ''},
+             {'read_tal_condition': '', 'field_name': 'description_rich', 'write_tal_condition': ''},
+             {'read_tal_condition': '', 'field_name': 'reference_number', 'write_tal_condition': ''},
+             {'read_tal_condition': '', 'field_name': 'plan', 'write_tal_condition': ''},
+             {'read_tal_condition': '', 'field_name': 'IAnalyticBudget.projection', 'write_tal_condition': ''},
+             {'read_tal_condition': '', 'field_name': 'IAnalyticBudget.analytic_budget', 'write_tal_condition': ''},
+             {'read_tal_condition': '', 'field_name': 'budget', 'write_tal_condition': ''},
+             {'read_tal_condition': '', 'field_name': 'budget_comments', 'write_tal_condition': ''},
+             {'read_tal_condition': '', 'field_name': 'observation', 'write_tal_condition': ''},
+             {'read_tal_condition': '', 'field_name': 'comments', 'write_tal_condition': ''}]
         )
         os_view = self.os1.unrestrictedTraverse('@@view')
         os_view.updateFieldsFromSchemata()

--- a/src/imio/project/pst/tests/test_pstprojectspace.py
+++ b/src/imio/project/pst/tests/test_pstprojectspace.py
@@ -16,9 +16,7 @@ class TestPSTProjectSpace(IntegrationTestCase):
         super(TestPSTProjectSpace, self).setUp()
 
     def test_default_setup(self):
-        """
-         Assert that pstprojectspace has default fields values
-        """
+        """Assert that pstprojectspace has default fields values."""
         self.assertEquals(self.pst.strategicobjective_fields, self.os_fields)
         self.assertEquals(self.pst.operationalobjective_fields, self.oo_fields)
         self.assertEquals(self.pst.pstaction_fields, self.a_fields)
@@ -31,12 +29,10 @@ class TestPSTProjectSpace(IntegrationTestCase):
         self.assertEquals(self.pst.pstaction_budget_states, self.a_bdg_states)
         self.assertEquals(self.pst.pstsubaction_budget_states, self.a_bdg_states)
 
-    def test_strategicobjectives_fields(self):
-        """
-         Test hide field :
+    def test_strategicobjectives_fields_hiding(self):
+        """Test hide field.
          remove categories in strategicobjectives_fields and assert that schemata fields has been updated
         """
-        import ipdb; ipdb.set_trace()
         self.assertEquals(
             self.pst.strategicobjective_fields,
             [{'read_tal_condition': '', 'field_name': 'IDublinCore.title', 'write_tal_condition': ''},
@@ -75,9 +71,88 @@ class TestPSTProjectSpace(IntegrationTestCase):
              'IAnalyticBudget.analytic_budget', 'budget', 'budget_comments', 'observation', 'comments']
         )
 
-    def test_pstsubaction_fields(self):
+    def test_strategicobjectives_fields_restriction(self):
+        """Test restriction of comment field to pst editors in OO context.
+        - Fill the Write TAL condition of the comment line of operationalobjective_fields fields
+         with a TAL condition evaluate to true for users in pst_editor group
+        - Login as psteditor and make sure that you have access to the field in both view and edit mode
+        - Login as chief and make sure that you do not have access to the field only in edit mode
         """
-         Test value when pstaction_fields modified :
+        self.pst.operationalobjective_fields = [
+            {'read_tal_condition': '', 'field_name': 'IDublinCore.title', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'description_rich', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'reference_number', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'categories', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'plan', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'result_indicator', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'priority', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'planned_end_date', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'representative_responsible', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'administrative_responsible', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'manager', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'extra_concerned_people', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'IAnalyticBudget.projection', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'IAnalyticBudget.analytic_budget', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'budget', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'budget_comments', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'ISustainableDevelopmentGoals.sdgs', 'write_tal_condition': ''},
+            {'read_tal_condition': '', 'field_name': 'observation', 'write_tal_condition': ''},
+            {
+                'read_tal_condition': '',
+                'field_name': 'comments',
+                'write_tal_condition':
+                    "python: 'pst_editors' in [group.id for group in portal.portal_groups.getGroupsByUserId(member.id)]"
+            }
+        ]
+        self.login('psteditor')
+        oo_view = self.oo1.restrictedTraverse('@@view')
+        oo_view.updateFieldsFromSchemata()
+        schema_fields = [fld for fld in oo_view.fields]
+        self.assertEquals(
+            schema_fields,
+            ['description_rich', 'reference_number', 'categories', 'plan', 'result_indicator', 'priority',
+             'planned_end_date', 'representative_responsible', 'administrative_responsible', 'manager',
+             'extra_concerned_people', 'IAnalyticBudget.projection', 'IAnalyticBudget.analytic_budget', 'budget',
+             'budget_comments', 'ISustainableDevelopmentGoals.sdgs', 'observation', 'comments']
+        )
+        oo_edit = self.oo1.restrictedTraverse('@@edit')
+        oo_edit.portal_type = oo_edit.context.portal_type
+        oo_edit.updateFields()
+        schema_fields = [fld for fld in oo_edit.fields]
+        self.assertEquals(
+            schema_fields,
+            ['IDublinCore.title', 'description_rich', 'reference_number', 'categories', 'plan', 'result_indicator',
+             'priority', 'planned_end_date', 'representative_responsible', 'administrative_responsible', 'manager',
+             'extra_concerned_people', 'budget', 'budget_comments', 'ISustainableDevelopmentGoals.sdgs', 'observation',
+             'comments']
+        )
+        self.assertNotEquals(oo_edit.fields.get('comments').mode, 'display')
+        self.login('chef')
+        oo_view = self.oo1.restrictedTraverse('@@view')
+        oo_view.updateFieldsFromSchemata()
+        schema_fields = [fld for fld in oo_view.fields]
+        self.assertEquals(
+            schema_fields,
+            ['description_rich', 'reference_number', 'categories', 'plan', 'result_indicator', 'priority',
+             'planned_end_date', 'representative_responsible', 'administrative_responsible', 'manager',
+             'extra_concerned_people', 'IAnalyticBudget.projection', 'IAnalyticBudget.analytic_budget', 'budget',
+             'budget_comments', 'ISustainableDevelopmentGoals.sdgs', 'observation', 'comments']
+        )
+        oo_edit = self.oo1.restrictedTraverse('@@edit')
+        oo_edit.portal_type = oo_edit.context.portal_type
+        oo_edit.updateFields()
+        schema_fields = [fld for fld in oo_view.fields]
+        self.assertEquals(
+            schema_fields,
+            ['description_rich', 'reference_number', 'categories', 'plan', 'result_indicator', 'priority',
+             'planned_end_date', 'representative_responsible', 'administrative_responsible', 'manager',
+             'extra_concerned_people', 'IAnalyticBudget.projection', 'IAnalyticBudget.analytic_budget', 'budget',
+             'budget_comments', 'ISustainableDevelopmentGoals.sdgs', 'observation', 'comments']
+        )
+        self.assertEquals(oo_edit.fields.get('comments').mode, 'display')
+
+    def test_pstsubaction_fields(self):
+        """Test value when pstaction_fields modified.
          remove plan in pstaction_fields and assert that pstsubaction_fields take same values
         """
         self.assertEquals(self.pst.pstsubaction_fields, self.pst.pstaction_fields)
@@ -96,8 +171,7 @@ class TestPSTProjectSpace(IntegrationTestCase):
         self.assertEquals(self.pst.pstsubaction_fields, self.pst.pstaction_fields)
 
     def test_strategicobjectives_columns(self):
-        """
-        Test dashboard columns config :
+        """Test dashboard columns config.
         remove select_row in strategicobjectives_columns and assert that dashboard config has been adapted
         """
         # Test dashboard columns config
@@ -121,8 +195,7 @@ class TestPSTProjectSpace(IntegrationTestCase):
         )
 
     def test_pstsubaction_budget_states(self):
-        """
-         Test value when pstaction_budget_states modified :
+        """Test value when pstaction_budget_states modified.
          remove 'to_be_scheduled' in pstaction_budget_states and assert that pstsubaction_budget_states take same values
         """
         self.login('psteditor')


### PR DESCRIPTION
Ticket PRJLIEA-6.

Il y a une pull request liée sur imio.project.core.

Notes:
- J'ai mis une migration de champs dans _Migrate_To_1_3_1_, je ne sais pas si ça vaut la peine de la mettre dans un _Migrator_ à part.
- Vu que les champs PST "_***_fields_" ont changé in situ, l'édition de l'objet PST n'est pas possible tant que la migration n'a pas tourné.
- Par contre, le contenu de ces champs reste utilisable avant et après la migration, car le code dans _manage_fields_ gère les 2 versions.
- Les expressions TAL sont évaluées grâce à du code de _collective.behavior.talcondition_. 