### PR TITLE
Move symlink origin link to ContentLink viewlet

### DIFF
--- a/src/imio/project/pst/browser/configure.zcml
+++ b/src/imio/project/pst/browser/configure.zcml
@@ -539,4 +539,13 @@
       layer="..interfaces.IImioProjectPSTLayer"
       />
 
+    <browser:viewlet
+      for="collective.task.interfaces.ITaskContent"
+      name="viewlet.ContentLink"
+      manager="plone.app.layout.viewlets.interfaces.IAboveContentTitle"
+      class=".viewlets.ContentLinkViewlet"
+      permission="zope.Public"
+      layer="..interfaces.IImioProjectPSTLayer"
+      />
+
 </configure>

--- a/src/imio/project/pst/browser/templates/contentlink.pt
+++ b/src/imio/project/pst/browser/templates/contentlink.pt
@@ -6,6 +6,7 @@
   </li>
   </ul>
 </div>
+<div id="original-link" tal:define="msg view/original_link" tal:condition="msg" tal:content="structure msg"></div>
 <div id="budget-split-link" tal:condition="view/budget_split_url">
   <a href="" tal:attributes="href view/budget_split_url"
     i18n:translate="">Split budget lines between multiple instances</a>

--- a/src/imio/project/pst/browser/viewlets.py
+++ b/src/imio/project/pst/browser/viewlets.py
@@ -80,6 +80,20 @@ class ContentLinkViewlet(ViewletBase):
             return [obj.aq_parent for obj in ref
                     if obj.absolute_url() != self.context.absolute_url()]
 
+    def original_link(self):
+        link_type, symlink_obj, original_obj, subpath = is_linked_object(self.context)
+        if link_type:
+            if subpath:
+                linked_context = original_obj.restrictedTraverse(subpath)
+            else:
+                linked_context = original_obj
+            msg = _(u"This content is a copy, to modify the original content click on this button ${edit}",
+                    mapping={"edit": '<a href="{0}/edit">{1}</a>'.format(
+                        linked_context.absolute_url(),
+                        _tr('Edit', domain='plone')
+                    )})
+            return msg
+
     def budget_split_url(self):
         if self.back_references(self.context) or hasattr(self.context, "_link_portal_type"):
             return '{}/@@budget_split'.format(self.context.absolute_url())
@@ -105,25 +119,6 @@ class ContextInformationViewlet(MessagesViewlet):
 
     def getAllMessages(self):
         ret = []
-
-        link_type, symlink_obj, original_obj, subpath = is_linked_object(self.context)
-        if link_type:
-            if subpath:
-                linked_context = original_obj.restrictedTraverse(subpath)
-            else:
-                linked_context = original_obj
-            msg = _(u"This content is a copy, to modify the original content click on this button ${edit}",
-                    mapping={"edit": '<a href="{0}/edit">{1}</a>'.format(
-                    linked_context.absolute_url(),
-                             _tr('Edit', domain='plone'))})
-            ret.append(
-                PseudoMessage(
-                    msg_type="significant",
-                    text=richtextval(msg),
-                    hidden_uid=generate_uid(),
-                    can_hide=False,
-                )
-            )
 
         if self.context.portal_type == "operationalobjective":
             if self.context.planned_end_date:


### PR DESCRIPTION
Ticket: PRJ-375

Déplacement vers le viewlet _ContentLink_ du lien permettant d'éditer l'origine d'un symlink.